### PR TITLE
Adding sparse checkout for textbook repo.

### DIFF
--- a/demo/install-demo.bash
+++ b/demo/install-demo.bash
@@ -2,4 +2,13 @@
 
 # FIXME: Find a way to pin these to a particular commit maybe?
 git clone --depth=1 https://github.com/data-8/tables-notebooks.git examples
-git clone --depth=1 https://github.com/data-8/textbook textbook
+
+# Sparse checkout of just index.ipynb and the notebooks folder in textbook repo.
+mkdir /home/jovyan/textbook 
+cd /home/jovyan/textbook
+git init 
+git config core.sparseCheckout true
+git remote add -f origin https://github.com/data-8/textbook.git
+echo "notebooks/*" >> .git/info/sparse-checkout
+echo "index.ipynb" >> .git/info/sparse-checkout
+git checkout gh-pages


### PR DESCRIPTION
Only checking out the notebooks from the textbook repo, not pulling unneeded files.